### PR TITLE
Add permissions to the manifest

### DIFF
--- a/cc.nift.nsm.json
+++ b/cc.nift.nsm.json
@@ -4,6 +4,10 @@
     "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "nsm",
+    "finish-args": [
+        "--filesystem=host",
+        "--share=network"
+    ],
     "modules": [
         {
             "name": "git",


### PR DESCRIPTION
Like I mentioned on reddit, this prevents having to pass all the perms (and pass --cwd), so the command line is cleaner and you can use an alias vs a function.